### PR TITLE
Update version of maven-shade-plugin

### DIFF
--- a/crafter-search-index-updater/pom.xml
+++ b/crafter-search-index-updater/pom.xml
@@ -68,7 +68,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
                 <executions>
                     <execution>
                         <id>executable-jar</id>


### PR DESCRIPTION
I ran into an error trying to build it when running maven version 3.1.1. Details are here: https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
