### PR TITLE
Fix integration tests failure

### DIFF
--- a/crafter-search-itest/pom.xml
+++ b/crafter-search-itest/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <!-- Cargo -->
         <cargo.container>jetty9x</cargo.container>
-        <cargo.container.url>http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.4.v20170414/jetty-distribution-9.4.4.v20170414.tar.gz</cargo.container.url>
+        <cargo.container.url>http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.6.v20170531/jetty-distribution-9.4.6.v20170531.tar.gz</cargo.container.url>
         <cargo.container.downloadDir>${user.home}/.m2/cargo/containers</cargo.container.downloadDir>
         <cargo.port>7070</cargo.port>
         <!-- Solr -->


### PR DESCRIPTION
The Jetty 9.4.4 distribution has a bug that makes "Crafter Search Integration Tests" fail. Switch to the latest 9.4.6 fixed the error.