### PR TITLE
Fixes for Elasticsearch:

### DIFF
--- a/crafter-search-elasticsearch/src/main/java/org/craftercms/search/elasticsearch/impl/MultiElasticsearchAdminServiceImpl.java
+++ b/crafter-search-elasticsearch/src/main/java/org/craftercms/search/elasticsearch/impl/MultiElasticsearchAdminServiceImpl.java
@@ -40,8 +40,9 @@ public class MultiElasticsearchAdminServiceImpl extends ElasticsearchAdminServic
     public MultiElasticsearchAdminServiceImpl(Resource authoringMapping, Resource previewMapping,
                                               String authoringNamePattern, Map<String, String> localeMapping,
                                               RestHighLevelClient elasticsearchClient,
-                                              RestHighLevelClient[] writeClients) {
-        super(authoringMapping, previewMapping, authoringNamePattern, localeMapping, elasticsearchClient);
+                                              Map<String, String> indexSettings, RestHighLevelClient[] writeClients) {
+        super(authoringMapping, previewMapping, authoringNamePattern, localeMapping, indexSettings,
+                elasticsearchClient);
         this.writeClients = writeClients;
     }
 

--- a/crafter-search-elasticsearch/src/main/resources/crafter/elasticsearch/authoring-mapping.json
+++ b/crafter-search-elasticsearch/src/main/resources/crafter/elasticsearch/authoring-mapping.json
@@ -1,4 +1,5 @@
 {
+  "date_detection": false,
   "properties": {
     "crafterSite": {
       "type": "keyword"

--- a/crafter-search-elasticsearch/src/main/resources/crafter/elasticsearch/default-mapping.json
+++ b/crafter-search-elasticsearch/src/main/resources/crafter/elasticsearch/default-mapping.json
@@ -1,4 +1,5 @@
 {
+  "date_detection": false,
   "properties": {
     "crafterSite": {
       "type": "keyword"


### PR DESCRIPTION
- Disable date detection
- Skip index recreate if not found
- Add support for custom index settings
- Copy supported index settings during recreate

craftercms/craftercms#4262, craftercms/craftercms#3929, craftercms/craftercms#4267
