### PR TITLE
Handle NoClassDefFoundError while parse binary with Tika

### DIFF
--- a/crafter-search-elasticsearch/src/main/java/org/craftercms/search/elasticsearch/impl/tika/TikaDocumentParser.java
+++ b/crafter-search-elasticsearch/src/main/java/org/craftercms/search/elasticsearch/impl/tika/TikaDocumentParser.java
@@ -106,6 +106,9 @@ public class TikaDocumentParser extends AbstractDocumentParser {
         } catch (IOException | TikaException e) {
             logger.error("Error parsing file", e);
             throw new SearchException("Error parsing file", e);
+        } catch (NoClassDefFoundError e) {
+            logger.error("No class def found error", e);
+            throw new SearchException("Error parsing file", e);
         }
     }
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Tika could throw an error at runtime if there are classes def missing