### PR TITLE
Duplicate Index Settings fix

### DIFF
--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/OpenSearchAdminService.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/OpenSearchAdminService.java
@@ -36,6 +36,15 @@ public interface OpenSearchAdminService extends AutoCloseable {
     void createIndex(String aliasName) throws OpenSearchException;
 
     /**
+     * Indicates if an index exists for the given alias
+     *
+     * @param aliasName the index alias
+     * @return true if the index exists, false otherwise
+     * @throws OpenSearchException if there is any error while checking the index
+     */
+    boolean indexExists(String aliasName) throws OpenSearchException;
+
+    /**
      * Creates an index for the given locale
      * @param aliasName the name of the alias
      * @param locale the locale for the index

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/batch/OpenSearchXmlFileBatchIndexer.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/batch/OpenSearchXmlFileBatchIndexer.java
@@ -72,7 +72,7 @@ public class OpenSearchXmlFileBatchIndexer extends AbstractXmlFileBatchIndexer {
                 // get the locale for the item
                 Locale locale = localeExtractor.extract(context, path);
                 if (locale != null) {
-                    // check if locale specific index exists
+                    // check if locale specific index indexExists
                     searchAdminService.createIndex(indexId, locale);
                     // update the index name
                     indexId += "-" + LocaleUtils.toString(locale);

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/impl/MultiOpenSearchAdminServiceImpl.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/impl/MultiOpenSearchAdminServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.core.io.Resource;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Extension of {@link OpenSearchAdminServiceImpl} that handles multiple OpenSearch clusters
@@ -40,8 +41,10 @@ public class MultiOpenSearchAdminServiceImpl extends OpenSearchAdminServiceImpl 
     public MultiOpenSearchAdminServiceImpl(Resource authoringMapping, Resource previewMapping,
                                            String authoringNamePattern, Map<String, String> localeMapping,
                                            RestHighLevelClient OpenSearchClient,
-                                           Map<String, String> indexSettings, RestHighLevelClient[] writeClients) {
-        super(authoringMapping, previewMapping, authoringNamePattern, localeMapping, indexSettings,
+                                           Map<String, String> indexSettings,
+                                           Set<String> ignoredSettings,
+                                           RestHighLevelClient[] writeClients) {
+        super(authoringMapping, previewMapping, authoringNamePattern, localeMapping, indexSettings, ignoredSettings,
                 OpenSearchClient);
         this.writeClients = writeClients;
     }
@@ -50,6 +53,13 @@ public class MultiOpenSearchAdminServiceImpl extends OpenSearchAdminServiceImpl 
     public void createIndex(String aliasName) throws OpenSearchException {
         for (RestHighLevelClient client : writeClients) {
             doCreateIndex(client, aliasName, null);
+        }
+    }
+
+    @Override
+    public void duplicateIndex(String srcAliasName, String destAliasName) throws OpenSearchException {
+        for (RestHighLevelClient client : writeClients) {
+            doDuplicateIndex(client, srcAliasName, destAliasName);
         }
     }
 

--- a/crafter-search-opensearch/src/test/resources/spring/application-context.xml
+++ b/crafter-search-opensearch/src/test/resources/spring/application-context.xml
@@ -101,6 +101,9 @@
         <constructor-arg name="defaultSettings">
             <map/>
         </constructor-arg>
+        <constructor-arg name="ignoredSettings">
+            <map/>
+        </constructor-arg>
         <constructor-arg name="openSearchClient" ref="restHighLevelSearchClient"/>
     </bean>
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6583
indexExists() operation.
CreateIndex will refresh settings if index exists already.
Fix index settings retrieval on duplicateIndex()

Please notice this PR and https://github.com/craftercms/deployer/pull/434 are interdependent