### PR TITLE
Feature/8344 5x

### DIFF
--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/ClientFactoryUtils.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/ClientFactoryUtils.java
@@ -74,14 +74,14 @@ public class ClientFactoryUtils {
 			logger.debug("Using default thread count");
 		}
 
-		if (connectionTimeout >= 0) {
+		if (connectionTimeout > 0) {
 			logger.debug("Using custom connect timeout: {}", connectionTimeout);
 			configBuilder.setConnectTimeout(connectionTimeout);
 		} else {
 			logger.debug("Using default connect timeout");
 		}
 
-		if (socketTimeout >= 0) {
+		if (socketTimeout > 0) {
 			logger.debug("Using custom socket timeout: {}", socketTimeout);
 			configBuilder.setSoTimeout(socketTimeout);
 		} else {

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/ClientFactoryUtils.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/ClientFactoryUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.search.opensearch.spring;
+
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.util.PublicSuffixMatcher;
+import org.apache.http.conn.util.PublicSuffixMatcherLoader;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.nio.conn.NoopIOSessionStrategy;
+import org.apache.http.nio.conn.SchemeIOSessionStrategy;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.apache.http.nio.reactor.IOReactorExceptionHandler;
+import org.apache.http.ssl.SSLContexts;
+import org.slf4j.Logger;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Helper class for OpenSearch client factories
+ */
+public class ClientFactoryUtils {
+	private static final Logger logger = getLogger(ClientFactoryUtils.class);
+
+	/**
+	 * Creates a {@link PoolingNHttpClientConnectionManager} with the given parameters
+	 *
+	 * @param connectionTimeout      the connection timeout in milliseconds
+	 * @param socketTimeout          the socket timeout in milliseconds
+	 * @param threadCount            the number of IO threads to use
+	 * @param socketKeepAlive        whether to enable socket keep-alive
+	 * @param maxTotalConnections    the maximum number of total connections
+	 * @param maxConnectionsPerRoute the maximum number of connections per route
+	 * @return the created {@link PoolingNHttpClientConnectionManager}
+	 * @throws IOReactorException if there is an error creating the IO reactor
+	 */
+	public static PoolingNHttpClientConnectionManager createConnectionManager(int connectionTimeout, int socketTimeout,
+																			  int threadCount, boolean socketKeepAlive,
+																			  int maxTotalConnections, int maxConnectionsPerRoute)
+			throws IOReactorException {
+		// Setup with everything just as the builder would do it
+		SSLContext sslcontext = SSLContexts.createDefault();
+		PublicSuffixMatcher publicSuffixMatcher = PublicSuffixMatcherLoader.getDefault();
+		HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier(publicSuffixMatcher);
+		SchemeIOSessionStrategy sslStrategy = new SSLIOSessionStrategy(sslcontext, null, null, hostnameVerifier);
+
+		// Create the custom reactor
+		IOReactorConfig.Builder configBuilder = IOReactorConfig.custom();
+
+		if (threadCount > 0) {
+			logger.debug("Using custom thread count: {}", threadCount);
+			configBuilder.setIoThreadCount(threadCount);
+		} else {
+			logger.debug("Using default thread count");
+		}
+
+		if (connectionTimeout >= 0) {
+			logger.debug("Using custom connect timeout: {}", connectionTimeout);
+			configBuilder.setConnectTimeout(connectionTimeout);
+		} else {
+			logger.debug("Using default connect timeout");
+		}
+
+		if (socketTimeout >= 0) {
+			logger.debug("Using custom socket timeout: {}", socketTimeout);
+			configBuilder.setSoTimeout(socketTimeout);
+		} else {
+			logger.debug("Using default socket timeout");
+		}
+
+		if (socketKeepAlive) {
+			logger.debug("Using socket keep alive");
+			configBuilder.setSoKeepAlive(true);
+		}
+
+		DefaultConnectingIOReactor reactor = new DefaultConnectingIOReactor(configBuilder.build());
+
+		// Set up a generic exception handler that just logs everything to prevent the client from shutting down
+		reactor.setExceptionHandler(new IOReactorExceptionHandler() {
+			@Override
+			public boolean handle(IOException e) {
+				logger.error("Error executing request", e);
+				return true;
+			}
+
+			@Override
+			public boolean handle(RuntimeException e) {
+				logger.error("Error executing request", e);
+				return true;
+			}
+		});
+
+		PoolingNHttpClientConnectionManager poolingNHttpClientConnectionManager = new PoolingNHttpClientConnectionManager(
+				reactor,
+				RegistryBuilder.<SchemeIOSessionStrategy>create()
+						.register("http", NoopIOSessionStrategy.INSTANCE)
+						.register("https", sslStrategy)
+						.build());
+		if (maxTotalConnections > 0) {
+			logger.debug("Using custom max total connections: {}", maxTotalConnections);
+			poolingNHttpClientConnectionManager.setMaxTotal(maxTotalConnections);
+		} else {
+			logger.debug("Using default max total connections");
+		}
+		if (maxConnectionsPerRoute > 0) {
+			logger.debug("Using custom max connections per route: {}", maxConnectionsPerRoute);
+			poolingNHttpClientConnectionManager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
+		} else {
+			logger.debug("Using default max connections per route");
+		}
+		return poolingNHttpClientConnectionManager;
+	}
+}

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/OpenSearchClientFactory.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/OpenSearchClientFactory.java
@@ -161,6 +161,7 @@ public class OpenSearchClientFactory extends AbstractFactoryBean<OpenSearchClien
 			if (connectTimeout >= 0) {
 				logger.debug("Using custom connect timeout: {}", connectTimeout);
 				builder.setConnectTimeout(connectTimeout);
+				builder.setConnectionRequestTimeout(connectTimeout);
 			} else {
 				logger.debug("Using default connect timeout");
 			}

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/OpenSearchClientFactory.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/OpenSearchClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -22,20 +22,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.apache.http.conn.util.PublicSuffixMatcher;
-import org.apache.http.conn.util.PublicSuffixMatcherLoader;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
-import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.apache.http.nio.conn.NoopIOSessionStrategy;
-import org.apache.http.nio.conn.SchemeIOSessionStrategy;
-import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.IOReactorException;
-import org.apache.http.nio.reactor.IOReactorExceptionHandler;
-import org.apache.http.ssl.SSLContexts;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
@@ -46,11 +34,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 import java.util.stream.Stream;
+
+import static org.craftercms.search.opensearch.spring.ClientFactoryUtils.createConnectionManager;
 
 /**
  * Implementation of {@link AbstractFactoryBean} to create instances of {@link OpenSearchClient}
@@ -96,102 +83,77 @@ public class OpenSearchClientFactory extends AbstractFactoryBean<OpenSearchClien
 	 * Indicates if socket keep alive should be enabled
 	 */
 	protected boolean socketKeepAlive = false;
+	/**
+	 * The maximum number of connections
+	 */
+	protected int maxTotalConnections = -1;
+	/**
+	 * The maximum number of connections per route
+	 */
+	protected int maxConnectionsPerRoute = -1;
 
 	@ConstructorProperties({"serverUrls"})
 	public OpenSearchClientFactory(final String[] serverUrls) {
 		this.serverUrls = serverUrls;
 	}
 
+	@SuppressWarnings("unused")
 	public void setUsername(final String username) {
 		this.username = username;
 	}
 
+	@SuppressWarnings("unused")
 	public void setPassword(final String password) {
 		this.password = password;
 	}
 
+	@SuppressWarnings("unused")
 	public void setConnectTimeout(int connectTimeout) {
 		this.connectTimeout = connectTimeout;
 	}
 
+	@SuppressWarnings("unused")
 	public void setSocketTimeout(int socketTimeout) {
 		this.socketTimeout = socketTimeout;
 	}
 
+	@SuppressWarnings("unused")
 	public void setThreadCount(int threadCount) {
 		this.threadCount = threadCount;
 	}
 
+	@SuppressWarnings("unused")
 	public void setSocketKeepAlive(boolean socketKeepAlive) {
 		this.socketKeepAlive = socketKeepAlive;
 	}
 
-	public static PoolingNHttpClientConnectionManager createConnectionManager(int connectionTimeout, int socketTimeout,
-										  int threadCount, boolean socketKeepAlive)
-		throws IOReactorException {
-		// Setup with everything just as the builder would do it
-		SSLContext sslcontext = SSLContexts.createDefault();
-		PublicSuffixMatcher publicSuffixMatcher = PublicSuffixMatcherLoader.getDefault();
-		HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier(publicSuffixMatcher);
-		SchemeIOSessionStrategy sslStrategy = new SSLIOSessionStrategy(sslcontext, null, null, hostnameVerifier);
-
-		// Create the custom reactor
-		IOReactorConfig.Builder configBuilder = IOReactorConfig.custom();
-
-		if (threadCount > 0) {
-			logger.debug("Using custom thread count: {}", threadCount);
-			configBuilder.setIoThreadCount(threadCount);
-		} else {
-			logger.debug("Using default thread count");
-		}
-
-		if (connectionTimeout >= 0) {
-			logger.debug("Using custom connect timeout: {}", connectionTimeout);
-			configBuilder.setConnectTimeout(connectionTimeout);
-		} else {
-			logger.debug("Using default connect timeout");
-		}
-
-		if (socketTimeout >= 0) {
-			logger.debug("Using custom socket timeout: {}", socketTimeout);
-			configBuilder.setSoTimeout(socketTimeout);
-		} else {
-			logger.debug("Using default socket timeout");
-		}
-
-		if (socketKeepAlive) {
-			logger.debug("Using socket keep alive");
-			configBuilder.setSoKeepAlive(true);
-		}
-
-		DefaultConnectingIOReactor reactor = new DefaultConnectingIOReactor(configBuilder.build());
-
-		// Set up a generic exception handler that just logs everything to prevent the client from shutting down
-		reactor.setExceptionHandler(new IOReactorExceptionHandler() {
-			@Override
-			public boolean handle(IOException e) {
-				logger.error("Error executing request", e);
-				return true;
-			}
-
-			@Override
-			public boolean handle(RuntimeException e) {
-				logger.error("Error executing request", e);
-				return true;
-			}
-		});
-
-		return new PoolingNHttpClientConnectionManager(
-			reactor,
-			RegistryBuilder.<SchemeIOSessionStrategy>create()
-				.register("http", NoopIOSessionStrategy.INSTANCE)
-				.register("https", sslStrategy)
-				.build());
+	@SuppressWarnings("unused")
+	public void setMaxConnectionsPerRoute(int maxConnectionsPerRoute) {
+		this.maxConnectionsPerRoute = maxConnectionsPerRoute;
 	}
 
+	@SuppressWarnings("unused")
+	public void setMaxTotalConnections(int maxTotalConnections) {
+		this.maxTotalConnections = maxTotalConnections;
+	}
+
+	/**
+	 * Creates an {@link OpenSearchClient} instance
+	 *
+	 * @param serverUrls             array of OpenSearch server URLs
+	 * @param username               the username
+	 * @param password               the password
+	 * @param connectTimeout         connection timeout
+	 * @param socketTimeout          socket timeout
+	 * @param threadCount            number of threads
+	 * @param socketKeepAlive        indicates if socket keep alive should be enabled
+	 * @param maxTotalConnections    maximum total connections
+	 * @param maxConnectionsPerRoute maximum connections per route
+	 * @return the {@link OpenSearchClient} instance
+	 */
 	public static OpenSearchClient createClient(String[] serverUrls, String username, String password,
-						    int connectTimeout, int socketTimeout, int threadCount,
-						    boolean socketKeepAlive) {
+												int connectTimeout, int socketTimeout, int threadCount,
+												boolean socketKeepAlive, int maxTotalConnections, int maxConnectionsPerRoute) {
 		logger.debug("Building client for urls: {}", (Object) serverUrls);
 		HttpHost[] hosts = Stream.of(serverUrls).map(HttpHost::create).toArray(HttpHost[]::new);
 		RestClientBuilder clientBuilder = RestClient.builder(hosts);
@@ -222,7 +184,7 @@ public class OpenSearchClientFactory extends AbstractFactoryBean<OpenSearchClien
 
 			try {
 				builder.setConnectionManager(
-					createConnectionManager(connectTimeout, socketTimeout, threadCount, socketKeepAlive));
+						createConnectionManager(connectTimeout, socketTimeout, threadCount, socketKeepAlive, maxTotalConnections, maxConnectionsPerRoute));
 			} catch (IOReactorException e) {
 				logger.warn("Error setting up custom exception handler", e);
 			}
@@ -232,10 +194,10 @@ public class OpenSearchClientFactory extends AbstractFactoryBean<OpenSearchClien
 		clientBuilder.setRequestConfigCallback(requestConfigCallback);
 		clientBuilder.setHttpClientConfigCallback(httpClientConfigCallback);
 		ObjectMapper mapper = new ObjectMapper()
-			.findAndRegisterModules()
-			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+				.findAndRegisterModules()
+				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		OpenSearchTransport transport = new RestClientTransport(clientBuilder.build(),
-			new JacksonJsonpMapper(mapper));
+				new JacksonJsonpMapper(mapper));
 		return new OpenSearchClient(transport);
 	}
 
@@ -247,7 +209,7 @@ public class OpenSearchClientFactory extends AbstractFactoryBean<OpenSearchClien
 	@Override
 	protected OpenSearchClient createInstance() {
 		return createClient(serverUrls, username, password, connectTimeout, socketTimeout, threadCount,
-			socketKeepAlive);
+				socketKeepAlive, maxTotalConnections, maxConnectionsPerRoute);
 	}
 
 	@Override

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/RestHighLevelClientFactory.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/RestHighLevelClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -21,20 +21,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.apache.http.conn.util.PublicSuffixMatcher;
-import org.apache.http.conn.util.PublicSuffixMatcherLoader;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
-import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.apache.http.nio.conn.NoopIOSessionStrategy;
-import org.apache.http.nio.conn.SchemeIOSessionStrategy;
-import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.IOReactorException;
-import org.apache.http.nio.reactor.IOReactorExceptionHandler;
-import org.apache.http.ssl.SSLContexts;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
@@ -42,11 +30,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 import java.util.stream.Stream;
+
+import static org.craftercms.search.opensearch.spring.ClientFactoryUtils.createConnectionManager;
 
 /**
  * Factory class for the OpenSearch rest client
@@ -55,7 +42,7 @@ import java.util.stream.Stream;
  */
 public class RestHighLevelClientFactory extends AbstractFactoryBean<RestHighLevelClient> {
 
-	private static final Logger logger = LoggerFactory.getLogger(OpenSearchClientFactory.class);
+	private static final Logger logger = LoggerFactory.getLogger(RestHighLevelClientFactory.class);
 
 	/**
 	 * List of OpenSearch urls
@@ -91,102 +78,63 @@ public class RestHighLevelClientFactory extends AbstractFactoryBean<RestHighLeve
 	 * Indicates if socket keep alive should be enabled
 	 */
 	protected boolean socketKeepAlive = false;
+	/**
+	 * The maximum number of connections
+	 */
+	protected int maxTotalConnections = -1;
+	/**
+	 * The maximum number of connections per route
+	 */
+	protected int maxConnectionsPerRoute = -1;
 
 	@ConstructorProperties({"serverUrls"})
 	public RestHighLevelClientFactory(final String[] serverUrls) {
 		this.serverUrls = serverUrls;
 	}
 
+	@SuppressWarnings("unused")
 	public void setUsername(final String username) {
 		this.username = username;
 	}
 
+	@SuppressWarnings("unused")
 	public void setPassword(final String password) {
 		this.password = password;
 	}
 
+	@SuppressWarnings("unused")
 	public void setConnectTimeout(int connectTimeout) {
 		this.connectTimeout = connectTimeout;
 	}
 
+	@SuppressWarnings("unused")
 	public void setSocketTimeout(int socketTimeout) {
 		this.socketTimeout = socketTimeout;
 	}
 
+	@SuppressWarnings("unused")
 	public void setThreadCount(int threadCount) {
 		this.threadCount = threadCount;
 	}
 
+	@SuppressWarnings("unused")
 	public void setSocketKeepAlive(boolean socketKeepAlive) {
 		this.socketKeepAlive = socketKeepAlive;
 	}
 
-	public static PoolingNHttpClientConnectionManager createConnectionManager(int connectionTimeout, int socketTimeout,
-										  int threadCount, boolean socketKeepAlive)
-		throws IOReactorException {
-		// Setup with everything just as the builder would do it
-		SSLContext sslcontext = SSLContexts.createDefault();
-		PublicSuffixMatcher publicSuffixMatcher = PublicSuffixMatcherLoader.getDefault();
-		HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier(publicSuffixMatcher);
-		SchemeIOSessionStrategy sslStrategy = new SSLIOSessionStrategy(sslcontext, null, null, hostnameVerifier);
+	@SuppressWarnings("unused")
+	public void setMaxConnectionsPerRoute(int maxConnectionsPerRoute) {
+		this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+	}
 
-		// Create the custom reactor
-		IOReactorConfig.Builder configBuilder = IOReactorConfig.custom();
-
-		if (threadCount > 0) {
-			logger.debug("Using custom thread count: {}", threadCount);
-			configBuilder.setIoThreadCount(threadCount);
-		} else {
-			logger.debug("Using default thread count");
-		}
-
-		if (connectionTimeout >= 0) {
-			logger.debug("Using custom connect timeout: {}", connectionTimeout);
-			configBuilder.setConnectTimeout(connectionTimeout);
-		} else {
-			logger.debug("Using default connect timeout");
-		}
-
-		if (socketTimeout >= 0) {
-			logger.debug("Using custom socket timeout: {}", socketTimeout);
-			configBuilder.setSoTimeout(socketTimeout);
-		} else {
-			logger.debug("Using default socket timeout");
-		}
-
-		if (socketKeepAlive) {
-			logger.debug("Using socket keep alive");
-			configBuilder.setSoKeepAlive(true);
-		}
-
-		DefaultConnectingIOReactor reactor = new DefaultConnectingIOReactor(configBuilder.build());
-
-		// Set up a generic exception handler that just logs everything to prevent the client from shutting down
-		reactor.setExceptionHandler(new IOReactorExceptionHandler() {
-			@Override
-			public boolean handle(IOException e) {
-				logger.error("Error executing request", e);
-				return true;
-			}
-
-			@Override
-			public boolean handle(RuntimeException e) {
-				logger.error("Error executing request", e);
-				return true;
-			}
-		});
-
-		return new PoolingNHttpClientConnectionManager(
-			reactor,
-			RegistryBuilder.<SchemeIOSessionStrategy>create()
-				.register("http", NoopIOSessionStrategy.INSTANCE)
-				.register("https", sslStrategy)
-				.build());
+	@SuppressWarnings("unused")
+	public void setMaxTotalConnections(int maxTotalConnections) {
+		this.maxTotalConnections = maxTotalConnections;
 	}
 
 	public static RestHighLevelClient createClient(String[] serverUrls, String username, String password,
-						       int connectTimeout, int socketTimeout, int threadCount,
-						       boolean socketKeepAlive) {
+												   int connectTimeout, int socketTimeout, int threadCount,
+												   boolean socketKeepAlive, int maxTotalConnections, int maxConnectionsPerRoute) {
 		logger.debug("Building client for urls: {}", (Object) serverUrls);
 		HttpHost[] hosts = Stream.of(serverUrls).map(HttpHost::create).toArray(HttpHost[]::new);
 		RestClientBuilder clientBuilder = RestClient.builder(hosts);
@@ -217,7 +165,7 @@ public class RestHighLevelClientFactory extends AbstractFactoryBean<RestHighLeve
 
 			try {
 				builder.setConnectionManager(
-					createConnectionManager(connectTimeout, socketTimeout, threadCount, socketKeepAlive));
+						createConnectionManager(connectTimeout, socketTimeout, threadCount, socketKeepAlive, maxTotalConnections, maxConnectionsPerRoute));
 			} catch (IOReactorException e) {
 				logger.warn("Error setting up custom exception handler", e);
 			}
@@ -232,7 +180,7 @@ public class RestHighLevelClientFactory extends AbstractFactoryBean<RestHighLeve
 	@Override
 	protected RestHighLevelClient createInstance() {
 		return createClient(serverUrls, username, password, connectTimeout, socketTimeout, threadCount,
-			socketKeepAlive);
+				socketKeepAlive, maxTotalConnections, maxConnectionsPerRoute);
 	}
 
 	@Override

--- a/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/RestHighLevelClientFactory.java
+++ b/crafter-search-opensearch/src/main/java/org/craftercms/search/opensearch/spring/RestHighLevelClientFactory.java
@@ -142,6 +142,7 @@ public class RestHighLevelClientFactory extends AbstractFactoryBean<RestHighLeve
 			if (connectTimeout >= 0) {
 				logger.debug("Using custom connect timeout: {}", connectTimeout);
 				builder.setConnectTimeout(connectTimeout);
+				builder.setConnectionRequestTimeout(connectTimeout);
 			} else {
 				logger.debug("Using default connect timeout");
 			}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8344
Make search connection pool configurable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable OpenSearch HTTP connection pool limits (max total and per-route).
  - Exposed setters to tune timeouts, thread count, socket keep-alive, and pool sizing.
  - Applied connection-request timeout when using pooled connections.
- Refactor
  - Moved HTTP connection manager creation to a shared utility for consistent SSL, verification, and pooling setup.
- Performance
  - Better stability and throughput under high concurrency via configurable pooling and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->